### PR TITLE
「ファイル配布」する際に不要なファイルを含めないようにしました

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -19,6 +19,7 @@ set(:branch){ raise "branch (that means branch, tag and SHA for git) must be giv
 
 # deploy
 set :deploy_via,     :copy
+set :copy_exclude,   ['.git', 'vendor/bundle']
 
 # 世代管理
 set :keep_releases, 3


### PR DESCRIPTION
運営ツールでのタイトルのデプロイの際、
バージョンセット登録→状態遷移アクションの『ファイル配布』にて、
タイトルアプリの .git 以下と vendor/bundle 以下は API サーバ上では不要なため含めないようにしました。

これにより、『ファイル配布』で実行されている、運営ツールからAPIサーバへ
転送するファイルのサイズが抑えられて『ファイル配布』にかかる時間が短縮されます。
